### PR TITLE
Simple tokenizer and test.  Replace only whole tokens.

### DIFF
--- a/test.prescad
+++ b/test.prescad
@@ -1,11 +1,12 @@
 constant assignments and shared modules go here
 !PRESCAD!
 x = abc();
+me = a(x);
 meep = a(x);
 y = q(x);
 // this is a comment
 qq = eggs;
 y = fg(y);
 z = r(y, x);
-w = r(z, meep);
+w = r(z, me, meep);
 spam(w);


### PR DESCRIPTION
Use a simple token matcher to ensure that tokens are replaced as whole words.  Just enough sophistication to separate out identifiers.
